### PR TITLE
Wrap source code blocks in <code> HTML elements

### DIFF
--- a/spec/clj_org/org_spec.clj
+++ b/spec/clj_org/org_spec.clj
@@ -138,8 +138,9 @@
 
 (describe-examples identity srcify
   "asdf"                            ["asdf"]
-  "#+BEGIN_SRC x\n123\n#+END_SRC\n" [[:pre {:class "lang_x"}
-                                      "123\n"]])
+  "#+BEGIN_SRC x\n123\n#+END_SRC\n" [[:pre
+                                      [:code {:class "lang_x"}
+                                       "123\n"]]])
 
 
 (describe-examples identity example-ify

--- a/src/clj_org/org.clj
+++ b/src/clj_org/org.clj
@@ -321,9 +321,9 @@
        (remove (partial every? empty?))
        (mapcat (fn [[_ before lang block]]
                  (cond
-                   (not before) [[:pre {:class (str "lang_" lang)} block]]
+                   (not before) [[:pre [:code {:class (str "lang_" lang)} block]]]
                    (not block) [before]
-                   :else [before [:pre {:class (str "lang_" lang)} block]])))))
+                   :else [before [:pre [:code {:class (str "lang_" lang)} block]]])))))
 
 
 (defn example-ify [txt]


### PR DESCRIPTION
HTML has a built in element for code blocks. Adding <code> tags can enable
things like highlightjs to work out of the box: https://highlightjs.org/usage/