### PR TITLE
Case insensitive src blocks

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-org "0.0.2"
+(defproject clj-org "0.0.3"
   :description "A Parser for Emacs Org Mode Files"
   :url "https://github.com/eigenhombre/clj-org"
   :license {:name "MIT"}

--- a/src/clj_org/org.clj
+++ b/src/clj_org/org.clj
@@ -302,21 +302,21 @@
                  (
                    (?:
                      (?!
-                       \#\+BEGIN_SRC.*/i\s+
+                       \#\+(?i)\bBEGIN_SRC\b\s+
                        \S+
                        \n
                        .+?
-                       \#\+END_SRC.*/i\n
+                       \#\+(?i)\bEND_SRC\b\n
                      )
                      .
                    )+
                  )?
                  (?:
-                   \#\+BEGIN_SRC.*/i\s+
+                   \#\+(?i)\bBEGIN_SRC\b\s+
                    (\S+)
                    \n
                    (.+?)
-                   \#\+END_SRC.*/i\n
+                   \#\+(?i)\bEND_SRC\b\n
                  )?")
        (remove (partial every? empty?))
        (mapcat (fn [[_ before lang block]]

--- a/src/clj_org/org.clj
+++ b/src/clj_org/org.clj
@@ -302,21 +302,21 @@
                  (
                    (?:
                      (?!
-                       \#\+BEGIN_SRC\s+
+                       \#\+BEGIN_SRC.*/i\s+
                        \S+
                        \n
                        .+?
-                       \#\+END_SRC\n
+                       \#\+END_SRC.*/i\n
                      )
                      .
                    )+
                  )?
                  (?:
-                   \#\+BEGIN_SRC\s+
+                   \#\+BEGIN_SRC.*/i\s+
                    (\S+)
                    \n
                    (.+?)
-                   \#\+END_SRC\n
+                   \#\+END_SRC.*/i\n
                  )?")
        (remove (partial every? empty?))
        (mapcat (fn [[_ before lang block]]


### PR DESCRIPTION
This is a fix for https://github.com/eigenhombre/clj-org/issues/3#issue-487584476  
It just makes source block tags case insensitive so that this works  
```org
#+begin_src
#+end_src
```